### PR TITLE
Use the new addon mapping format

### DIFF
--- a/taarweb/demo/templates/taar/base.html
+++ b/taarweb/demo/templates/taar/base.html
@@ -19,5 +19,27 @@
     <!-- jQuery (necessary for Bootstrap's JavaScript plugins) -->
     <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.12.4/jquery.min.js"></script>
     <!-- Include all compiled plugins (below), or include individual files as needed -->
+    <script type="text/javascript">
+      $(document).ready(function() {
+          var BASE_AMO_URL = "https://addons.mozilla.org/api/v3/addons/addon/";
+          $('#recommendations > a').each(function () {
+              var linkElement = this;
+              var infoURL = BASE_AMO_URL + linkElement.text;
+              // Request the addon info from AMO.
+              $.getJSON(infoURL, {}, function (data, status) {
+                  // Get the data for the addon.
+                  var defaultLocale = data.default_locale;
+                  var addonName = data.name[defaultLocale];
+                  var desc = data.description[defaultLocale];
+                  // Update the DOM element with the data.
+                  $(linkElement).attr('href', data.url);
+                  $(linkElement).attr('title', desc);
+                  $(linkElement).text(addonName);
+                  // Show the element once we have the addon info.
+                  $(linkElement).show();
+              });
+          });
+      });
+    </script>
   </body>
 </html>

--- a/taarweb/demo/templates/taar/index.html
+++ b/taarweb/demo/templates/taar/index.html
@@ -38,10 +38,9 @@
 </div>
 <div class="col-sm-4">
     {% if form.is_valid and form.data.client_id %}
-      <div class="list-group">
+      <div id="recommendations" class="list-group">
       {% for recommendation in recommendations %}
-        <a href="https://addons.mozilla.org/en-US/firefox/search/?q={{recommendation}}"
-           class="list-group-item">{{ recommendation }}</a>
+        <a class="list-group-item" style="display:none">{{ recommendation }}</a>
       {% empty %}
       No recommendations found :(
       {% endfor %}

--- a/taarweb/demo/views.py
+++ b/taarweb/demo/views.py
@@ -37,7 +37,7 @@ def get_client_recommendations(request):
                     error_text = ("It wasn't possible to retrieve"
                                   "the list of addons")
                 cache.set('addon_mapping', addon_mapping)
-            recommendations = [addon_mapping.get(r, "")
+            recommendations = [addon_mapping.get(r, {}).get("id")
                                for r in recommendations]
     context = {
         'form': form,


### PR DESCRIPTION
This enabled the the TAAR web UI to behave correctly when addon ids are returned by the backend service.